### PR TITLE
Updated bm-inventory client and use "HostStageWaitingForControlPlane"…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/ajeddeloh/go-json v0.0.0-20200220154158-5ae607161559 // indirect
 	github.com/coreos/ignition v0.35.0
-	github.com/filanov/bm-inventory v1.0.6-0.20200715181832-13822c3e5bbb
+	github.com/filanov/bm-inventory v1.0.6
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/golang/mock v1.4.0
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,8 @@ github.com/filanov/bm-inventory v1.0.6-0.20200715115300-aa7735c912d7 h1:/jexwPBp
 github.com/filanov/bm-inventory v1.0.6-0.20200715115300-aa7735c912d7/go.mod h1:qhYn8CX9D8vUGa6/g+V/6+giDj8fAeGlEZZTLZZz5sw=
 github.com/filanov/bm-inventory v1.0.6-0.20200715181832-13822c3e5bbb h1:SI37cmjgegYph4O399enPGzNMcnMX+1aau4Ll8805V8=
 github.com/filanov/bm-inventory v1.0.6-0.20200715181832-13822c3e5bbb/go.mod h1:qH8cptTSrjDTPThOIQJVRywKqyAAzZrMk/2/lQIPd2Q=
+github.com/filanov/bm-inventory v1.0.6 h1:ZofmJEblKvX1WehI86AyxsB4BNoenVcs2/8BjpbvZ9A=
+github.com/filanov/bm-inventory v1.0.6/go.mod h1:qH8cptTSrjDTPThOIQJVRywKqyAAzZrMk/2/lQIPd2Q=
 github.com/filanov/stateswitch v0.0.0-20200513095115-051501b05b45/go.mod h1:sk33Oz1ABVidMrVdJfd6tj7n9exK/PZarClHJNnFIQ8=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -125,7 +125,7 @@ func (i *installer) InstallNode() error {
 		i.log.Info("Done writing image to disk")
 	}
 	if isBootstrap {
-		i.UpdateHostInstallProgress(models.HostStageStartWaitingForControlPlane, "")
+		i.UpdateHostInstallProgress(models.HostStageWaitingForControlPlane, "")
 		if err = errs.Wait(); err != nil {
 			i.log.Error(err)
 			return err

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -158,7 +158,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		}
 		It("bootstrap role happy flow", func() {
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
-				{string(models.HostStageStartWaitingForControlPlane)},
+				{string(models.HostStageWaitingForControlPlane)},
 				{string(models.HostStageInstalling), string(models.HostRoleMaster)},
 				{string(models.HostStageWritingImageToDisk), "0%"},
 				{string(models.HostStageRebooting)},
@@ -185,7 +185,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		})
 		It("bootstrap role fail", func() {
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
-				{string(models.HostStageStartWaitingForControlPlane)},
+				{string(models.HostStageWaitingForControlPlane)},
 				{string(models.HostStageInstalling), string(models.HostRoleMaster)},
 				{string(models.HostStageWritingImageToDisk), "0%"},
 			})
@@ -211,7 +211,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
 				{string(models.HostStageInstalling), string(models.HostRoleMaster)},
 				{string(models.HostStageWritingImageToDisk), "0%"},
-				{string(models.HostStageStartWaitingForControlPlane)},
+				{string(models.HostStageWaitingForControlPlane)},
 			})
 			cleanInstallDevice()
 			mkdirSuccess()


### PR DESCRIPTION
… instead of "HostStageStartWaitingForControlPlane"

This PR will wait for a couple of days before merged so most bm-inventory deployments will accept the "HostStageWaitingForControlPlane"