### PR TITLE
OCPBUGSM-11358 Cluster Events is missing the writing to disk progress logs

### DIFF
--- a/src/installer/installer.go
+++ b/src/installer/installer.go
@@ -109,7 +109,7 @@ func (i *installer) InstallNode() error {
 		return err
 	}
 
-	i.UpdateHostInstallProgress(models.HostStageWritingImageToDisk, "0%")
+	i.UpdateHostInstallProgress(models.HostStageWritingImageToDisk, "")
 
 	image, _ := utils.GetRhcosImageByOpenshiftVersion(i.OpenshiftVersion)
 	i.log.Infof("Going to use image: %s", image)

--- a/src/installer/installer_test.go
+++ b/src/installer/installer_test.go
@@ -160,7 +160,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
 				{string(models.HostStageWaitingForControlPlane)},
 				{string(models.HostStageInstalling), string(models.HostRoleMaster)},
-				{string(models.HostStageWritingImageToDisk), "0%"},
+				{string(models.HostStageWritingImageToDisk)},
 				{string(models.HostStageRebooting)},
 			})
 			cleanInstallDevice()
@@ -187,7 +187,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
 				{string(models.HostStageWaitingForControlPlane)},
 				{string(models.HostStageInstalling), string(models.HostRoleMaster)},
-				{string(models.HostStageWritingImageToDisk), "0%"},
+				{string(models.HostStageWritingImageToDisk)},
 			})
 			cleanInstallDevice()
 			mkdirSuccess()
@@ -210,7 +210,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		It("bootstrap fail to restart NetworkManager", func() {
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
 				{string(models.HostStageInstalling), string(models.HostRoleMaster)},
-				{string(models.HostStageWritingImageToDisk), "0%"},
+				{string(models.HostStageWritingImageToDisk)},
 				{string(models.HostStageWaitingForControlPlane)},
 			})
 			cleanInstallDevice()
@@ -272,7 +272,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		It("master role happy flow", func() {
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
 				{string(models.HostStageInstalling), conf.Role},
-				{string(models.HostStageWritingImageToDisk), "0%"},
+				{string(models.HostStageWritingImageToDisk)},
 				{string(models.HostStageRebooting)},
 			})
 			cleanInstallDevice()
@@ -329,7 +329,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		It("HostRoleMaster role failed to write image to disk", func() {
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
 				{string(models.HostStageInstalling), conf.Role},
-				{string(models.HostStageWritingImageToDisk), "0%"},
+				{string(models.HostStageWritingImageToDisk)},
 			})
 			cleanInstallDevice()
 			mkdirSuccess()
@@ -342,7 +342,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		It("HostRoleMaster role failed to reboot", func() {
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
 				{string(models.HostStageInstalling), conf.Role},
-				{string(models.HostStageWritingImageToDisk), "0%"},
+				{string(models.HostStageWritingImageToDisk)},
 				{string(models.HostStageRebooting)},
 			})
 			cleanInstallDevice()
@@ -370,7 +370,7 @@ var _ = Describe("installer HostRoleMaster role", func() {
 		It("worker role happy flow", func() {
 			updateProgressSuccess([][]string{{string(models.HostStageStartingInstallation), conf.Role},
 				{string(models.HostStageInstalling), conf.Role},
-				{string(models.HostStageWritingImageToDisk), "0%"},
+				{string(models.HostStageWritingImageToDisk)},
 				{string(models.HostStageRebooting)},
 			})
 			cleanInstallDevice()

--- a/src/ops/coreos_installer_log_writer.go
+++ b/src/ops/coreos_installer_log_writer.go
@@ -26,26 +26,20 @@ func NewCoreosInstallerLogWriter(logger *logrus.Logger, progressReporter invento
 	return &CoreosInstallerLogWriter{log: logger,
 		lastLogLine:      []byte{},
 		progressReporter: progressReporter,
-		progressRegex:    regexp.MustCompile(`^>(.*?)\((.*?)\)\s*\r`),
+		progressRegex:    regexp.MustCompile(`(.*?)\((.*?\%)\)\s*`),
 		hostID:           hostID,
 		lastProgress:     0,
 	}
 }
 
 func (l *CoreosInstallerLogWriter) Write(p []byte) (n int, err error) {
-	if bytes.Contains(p, []byte{'\n'}) {
-		// If log has a new line - log it
-		l.log.Info(string(p))
-	} else {
-		// Append bytes to last log line slice
-		l.lastLogLine = append(l.lastLogLine, p...)
-		if bytes.Contains(l.lastLogLine, []byte{'\r'}) {
-			// If log contains carriage return - log it and set to empty slice
-			l.log.Info(string(l.lastLogLine))
-			l.reportProgress()
-			l.lastLogLine = []byte{}
-
-		}
+	// Append bytes to last log line slice
+	l.lastLogLine = append(l.lastLogLine, p...)
+	if bytes.Contains(l.lastLogLine, []byte{'\r'}) || bytes.Contains(l.lastLogLine, []byte{'\n'}) {
+		// If log contains new line or carriage return - log it and set to empty slice
+		l.log.Info(string(l.lastLogLine))
+		l.reportProgress()
+		l.lastLogLine = []byte{}
 	}
 	return len(p), nil
 }


### PR DESCRIPTION
    Updated CoreosInstallerLogWriter regex to match the new coreos-installerr output
    coreos-installer version was updated from 0.1.2 to 0.2.0